### PR TITLE
Add parallel session isolation support

### DIFF
--- a/numina-lean-mcp.sh
+++ b/numina-lean-mcp.sh
@@ -5,10 +5,61 @@ PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LOG_NAME="${MCP_LOG_NAME:-mcp_lean_lsp}"
 LOG_DIR="${MCP_LOG_DIR:-$PROJECT_DIR}"
 
-# check if log_dir exists
 if [ ! -d "$LOG_DIR" ]; then
     mkdir -p "$LOG_DIR"
 fi
 
-#exec uvx --with-editable "$PROJECT_DIR" python -m lean_lsp_mcp.server 2>> "$PROJECT_DIR/mcp_lean_lsp.log"
+# -----------------------------------------------------------------------
+# Isolation: when LEAN_PROJECT_PATH is set and has a .lake directory,
+# create an isolated copy so multiple MCP processes don't conflict.
+#
+# - Config files (lakefile.toml, lean-toolchain, etc.) are copied
+# - Source dirs/files are symlinked back to the original (zero overhead)
+# - .lake/packages is symlinked (shared, ~7GB)
+# - .lake/build is copied (isolated per session, ~100-200MB)
+# -----------------------------------------------------------------------
+if [ -n "$LEAN_PROJECT_PATH" ] && [ -d "$LEAN_PROJECT_PATH/.lake" ]; then
+    SESSION_DIR="/tmp/lean-mcp-session-$$"
+    mkdir -p "$SESSION_DIR/.lake"
+
+    # Copy config files that lake needs to be real files
+    for f in lakefile.toml lakefile.lean lean-toolchain lake-manifest.json; do
+        [ -f "$LEAN_PROJECT_PATH/$f" ] && cp "$LEAN_PROJECT_PATH/$f" "$SESSION_DIR/"
+    done
+
+    # Symlink everything else (source dirs, .lean files, .git, etc.)
+    for item in "$LEAN_PROJECT_PATH"/*; do
+        name=$(basename "$item")
+        case "$name" in
+            .lake|lakefile.toml|lakefile.lean|lean-toolchain|lake-manifest.json) continue ;;
+        esac
+        [ ! -e "$SESSION_DIR/$name" ] && ln -s "$item" "$SESSION_DIR/$name"
+    done
+    # Hidden files (.gitignore, .git, etc.)
+    for item in "$LEAN_PROJECT_PATH"/.*; do
+        name=$(basename "$item")
+        case "$name" in
+            .|..|.lake) continue ;;
+        esac
+        [ ! -e "$SESSION_DIR/$name" ] && ln -s "$item" "$SESSION_DIR/$name"
+    done
+
+    # .lake/packages: symlink (shared, read-only)
+    [ -d "$LEAN_PROJECT_PATH/.lake/packages" ] && \
+        ln -s "$LEAN_PROJECT_PATH/.lake/packages" "$SESSION_DIR/.lake/packages"
+
+    # .lake/build: copy (isolated per session)
+    if [ -d "$LEAN_PROJECT_PATH/.lake/build" ]; then
+        cp -a "$LEAN_PROJECT_PATH/.lake/build" "$SESSION_DIR/.lake/build"
+    else
+        mkdir -p "$SESSION_DIR/.lake/build"
+    fi
+
+    # Clean up on exit
+    cleanup() { rm -rf "$SESSION_DIR"; }
+    trap cleanup EXIT INT TERM
+
+    export LEAN_PROJECT_PATH="$SESSION_DIR"
+fi
+
 exec uvx --with-editable "$PROJECT_DIR" python -m lean_lsp_mcp.server 2>> "$LOG_DIR/$LOG_NAME.log"

--- a/src/lean_lsp_mcp/client_utils.py
+++ b/src/lean_lsp_mcp/client_utils.py
@@ -1,10 +1,12 @@
 import os
+import urllib.parse
 from pathlib import Path
 from threading import Lock
 
 from mcp.server.fastmcp import Context
 from mcp.server.fastmcp.utilities.logging import get_logger
 from leanclient import LeanLSPClient
+from leanclient.base_client import BaseLeanLSPClient
 
 from lean_lsp_mcp.file_utils import get_relative_file_path
 from lean_lsp_mcp.utils import OutputCapture
@@ -12,6 +14,99 @@ from lean_lsp_mcp.utils import OutputCapture
 
 logger = get_logger(__name__)
 CLIENT_LOCK = Lock()
+
+
+# ---------------------------------------------------------------------------
+# Monkey-patch leanclient to avoid resolving symlinks.
+#
+# BaseLeanLSPClient uses Path.resolve() in three places, which follows
+# symlinks.  This breaks the "isolated .lake with symlinked sources"
+# approach because the resolved path escapes the isolated project dir.
+#
+# We replace .resolve() with os.path.abspath() which normalises ".." but
+# does NOT follow symlinks.  Behaviour is identical when no symlinks exist.
+# ---------------------------------------------------------------------------
+
+def _patched_init(self, project_path, initial_build=False, prevent_cache_get=False):
+    """BaseLeanLSPClient.__init__ with abspath instead of resolve."""
+    import subprocess
+    import threading
+    import asyncio
+    import atexit
+    from leanclient.utils import SemanticTokenProcessor, has_mathlib_dependency
+
+    self.project_path = Path(os.path.abspath(project_path))
+    self.request_id = 0
+
+    if initial_build:
+        self.build_project(get_cache=not prevent_cache_get)
+    elif not prevent_cache_get and has_mathlib_dependency(self.project_path):
+        subprocess.run(
+            ["lake", "exe", "cache", "get"],
+            cwd=self.project_path,
+            check=False,
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+        )
+
+    self.process = subprocess.Popen(
+        ["lake", "serve"],
+        cwd=self.project_path,
+        stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    self.stdin = self.process.stdin
+    self.stdout = self.process.stdout
+
+    self._loop = asyncio.new_event_loop()
+    self._futures = {}
+    self._notification_handlers = {}
+
+    self._loop_thread = threading.Thread(target=self._run_event_loop, daemon=True)
+    self._loop_thread.start()
+
+    self._stdout_thread_stop_event = threading.Event()
+    self._stdout_thread = threading.Thread(
+        target=self._read_stdout_loop,
+        args=(self._stdout_thread_stop_event,),
+        daemon=True,
+    )
+    self._stdout_thread.start()
+
+    server_info = self._send_request_sync(
+        "initialize",
+        {
+            "processId": os.getpid(),
+            "rootUri": self._local_to_uri(self.project_path),
+            "initializationOptions": {"editDelay": 1},
+        },
+    )
+
+    legend = server_info["capabilities"]["semanticTokensProvider"]["legend"]
+    self.token_processor = SemanticTokenProcessor(legend["tokenTypes"])
+    self._send_notification("initialized", {})
+    atexit.register(self.close)
+
+
+def _patched_local_to_uri(self, local_path):
+    """Convert local path to URI without resolving symlinks."""
+    path = Path(os.path.abspath(self.project_path / Path(local_path)))
+    return urllib.parse.unquote(path.as_uri())
+
+
+def _patched_uri_to_local(self, uri):
+    """Convert URI to local relative path without resolving symlinks."""
+    abs_path = Path(os.path.abspath(self._uri_to_abs(uri)))
+    try:
+        return str(abs_path.relative_to(self.project_path))
+    except ValueError:
+        return str(abs_path)
+
+
+BaseLeanLSPClient.__init__ = _patched_init
+BaseLeanLSPClient._local_to_uri = _patched_local_to_uri
+BaseLeanLSPClient._uri_to_local = _patched_uri_to_local
 
 
 def startup_client(ctx: Context):

--- a/src/lean_lsp_mcp/server.py
+++ b/src/lean_lsp_mcp/server.py
@@ -136,6 +136,14 @@ def log_tool_execution(func):
                 raise
         
         return sync_wrapper
+
+def run_in_thread(func):
+    """将同步阻塞函数包装为 async，在独立线程中执行，避免阻塞事件循环"""
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        return await asyncio.to_thread(func, *args, **kwargs)
+    return wrapper
+
 # Server and context
 @dataclass
 class AppContext:
@@ -1242,6 +1250,7 @@ def _log_gemini_prover_call(math_problem: str, solution: str, verification: str)
 
 @mcp.tool("gemini_informal_prover")
 @log_tool_execution
+@run_in_thread
 def gemini_informal_prover(
     ctx: Context,
     math_problem: str,
@@ -1391,6 +1400,7 @@ def _log_gpt_prover_call(math_problem: str, solution: str, verification: str):
 
 @mcp.tool("gpt_informal_prover")
 @log_tool_execution
+@run_in_thread
 def gpt_informal_prover(
     ctx: Context,
     math_problem: str,
@@ -1525,6 +1535,7 @@ def gpt_informal_prover(
 
 @mcp.tool("discussion_partner")
 @log_tool_execution
+@run_in_thread
 def discussion_partner(
     ctx: Context,
     question: str,


### PR DESCRIPTION
- Monkey-patch leanclient to use abspath instead of resolve, enabling symlinked source dirs
- Add isolation logic in numina-lean-mcp.sh: when LEAN_PROJECT_PATH is set, create per-session copy with symlinked sources and isolated .lake/build
- Trap EXIT/INT/TERM signals for cleanup